### PR TITLE
ci: remove pull request trigger from model catalog update workflow

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -6,9 +6,6 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
     # Allow manual triggering
-  pull_request:
-    branches:
-      - main
 
 env:
   PYTHON_VERSION: '3.11'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/update-model-catalog.yml` file. The change removes the ability to trigger the workflow on `pull_request` events targeting the `main` branch.