### PR TITLE
ci: remove pr trigger from model catalog workflow

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -6,8 +6,6 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
     # Allow manual triggering
-  pull_request:
-    branches: ["main"]
 
 env:
   PYTHON_VERSION: '3.11'


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow configuration to remove the automatic triggering of the `update-model-catalog.yml` workflow on pull requests to the `main` branch.

Workflow configuration update:

* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bL9-L10): Removed the `pull_request` trigger for the `main` branch, leaving only the `cron` schedule and manual `workflow_dispatch` as triggers.