### PR TITLE
ci: change to self hosted runner and update base url

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          BASE_URL: ${{ secrets.BASE_URL }}
         run: |
           python prepare_catalog.py | tee script_output.log
         timeout-minutes: 90

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -18,7 +18,7 @@ priority_devs = ["Menlo", "cortexso"]
 DESIRED_TAGS = {"text-generation", "conversational", "llama"}
 
 client = openai.OpenAI(
-    base_url="https://nano.jan.ai/v1",
+    base_url=os.getenv("BASE_URL"),
     api_key=os.getenv("OPENAI_API_KEY")
 )
 


### PR DESCRIPTION
This pull request updates the workflow and script to improve configurability and ensure compatibility with the latest environment. The most important changes include updating the runner version in the GitHub Actions workflow, adding a new environment variable for the base URL, and modifying the script to use the new environment variable.

### Workflow updates:
* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bL15-R15): Updated the runner version from `ubuntu-latest` to `ubuntu-22-04` to ensure compatibility with a specific Ubuntu version.
* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bR47): Added a new `BASE_URL` environment variable sourced from GitHub secrets to make the base URL configurable.

### Script updates:
* [`prepare_catalog.py`](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L21-R21): Replaced the hardcoded base URL with a dynamic value retrieved from the `BASE_URL` environment variable to improve flexibility.