### PR TITLE
ci: add github cli step

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -31,6 +31,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Set up GitHub CLI
+        uses: actions4gh/setup-gh@v1
+        with:
+          token: ${{ secrets.PAT_SERVICE_ACCOUNT }}
+
       - name: Set date variables
         id: date
         run: |


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow file `.github/workflows/update-model-catalog.yml`. The change adds a step to set up the GitHub CLI using the `actions4gh/setup-gh` action.

* Workflow enhancement:
  * [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bR34-R38): Added a new step to set up the GitHub CLI with a service account token (`secrets.PAT_SERVICE_ACCOUNT`) to support future GitHub CLI operations.