### PR TITLE
chore: remove api key on workflows and script file

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Run model catalog update script
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BASE_URL: ${{ secrets.BASE_URL }}
         run: |

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -5,7 +5,6 @@ import re
 import time
 from collections import defaultdict
 
-import openai
 import requests
 
 # --- Configuration ---
@@ -24,9 +23,6 @@ BLACKLISTED_DEVELOPERS = {
     "TheBloke",
 }
 
-client = openai.OpenAI(
-    base_url=os.getenv("BASE_URL"), api_key=os.getenv("OPENAI_API_KEY")
-)
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 HEADERS = {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}


### PR DESCRIPTION
This pull request removes dependencies on the OpenAI API by eliminating its usage in the model catalog update workflow and related scripts. The most important changes include removing references to the OpenAI API key in the GitHub Actions workflow and deleting the OpenAI client initialization in the Python script.

### Removal of OpenAI API dependencies:

* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bL50): Removed the `OPENAI_API_KEY` environment variable from the workflow configuration.
* [`prepare_catalog.py`](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L8): Deleted the import statement for the `openai` library and removed the initialization of the OpenAI client, including references to the `BASE_URL` and `OPENAI_API_KEY` environment variables. [[1]](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L8) [[2]](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L27-L29)