### PR TITLE
chore: add client api key

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Run model catalog update script
         env:
+          API_KEY: ${{ secrets.API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BASE_URL: ${{ secrets.BASE_URL }}
         run: |

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 from collections import defaultdict
-
+import openai
 import requests
 
 # --- Configuration ---
@@ -23,6 +23,7 @@ BLACKLISTED_DEVELOPERS = {
     "TheBloke",
 }
 
+client = openai.OpenAI(base_url=os.getenv("BASE_URL"))
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 HEADERS = {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -23,7 +23,10 @@ BLACKLISTED_DEVELOPERS = {
     "TheBloke",
 }
 
-client = openai.OpenAI(base_url=os.getenv("BASE_URL"))
+client = openai.OpenAI(
+    base_url=os.getenv("BASE_URL"),
+    api_key=os.getenv("API_KEY"),
+)
 
 HF_TOKEN = os.getenv("HF_TOKEN")
 HEADERS = {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}


### PR DESCRIPTION
This pull request introduces a small change to the `prepare_catalog.py` file by adding the `openai` library and initializing an OpenAI client. These updates are likely in preparation for integrating OpenAI's services into the script.

* [`prepare_catalog.py`](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L7-R7): Imported the `openai` library and initialized an OpenAI client using a base URL from the `BASE_URL` environment variable. [[1]](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7L7-R7) [[2]](diffhunk://#diff-0a90616aac1e01950678f5560abe3ef2e99ea6f975ab0742cf00b966dd64dfc7R26)