### PR TITLE
ci: remove auto merge and add human in the loop for review pr

### DIFF
--- a/.github/workflows/update-model-catalog.yml
+++ b/.github/workflows/update-model-catalog.yml
@@ -71,6 +71,7 @@ jobs:
           branch: update-model-catalog-${{ steps.date.outputs.today_with_time }}
           commit-message: "🤖 Auto-update model catalog - ${{ steps.date.outputs.datetime }}"
           title: "🤖 Auto-update Model Catalog - ${{ steps.date.outputs.datetime_short }}"
+          reviewers: Minh141120,qnixsynapse
           body: |
             ## 🤖 Automated Model Catalog Update
 
@@ -80,30 +81,4 @@ jobs:
 
             - **New models added:** ${{ steps.extract-summary.outputs.new_models }}
             - **Total models in catalog:** ${{ steps.extract-summary.outputs.total_models }} 
-
-      - name: Auto-merge PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_SERVICE_ACCOUNT }}
-        run: |
-          PR_NUMBER=$(gh pr list --search "🤖 Auto-update Model Catalog" --json number --jq '.[0].number')
-          
-          if [ -n "$PR_NUMBER" ]; then
-            echo "Found PR number: $PR_NUMBER"
-            sleep 10
-            
-            # Check if PR is mergeable
-            MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq '.mergeable')
-            echo "PR mergeable status: $MERGEABLE"
-            
-            if [ "$MERGEABLE" = "MERGEABLE" ]; then
-              echo "Merging PR $PR_NUMBER"
-              gh pr merge --auto --merge "$PR_NUMBER"
-              gh pr comment "$PR_NUMBER" --body "🤖 Auto-merged by GitHub Actions"
-            else
-              echo "PR is not mergeable"
-              gh pr comment "$PR_NUMBER" --body "🤖 PR is not mergeable, please review and merge manually"
-            fi
-          else
-            echo "No PR number found"
-          fi
           


### PR DESCRIPTION
This pull request updates the workflow for the `update-model-catalog` GitHub Action by adding reviewers to the auto-generated pull requests and removing the auto-merge functionality. These changes aim to improve the review process and ensure manual oversight for merging.

### Workflow updates:

* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bR74): Added `Minh141120` and `qnixsynapse` as reviewers for the auto-generated pull requests to ensure proper review and accountability.
* [`.github/workflows/update-model-catalog.yml`](diffhunk://#diff-44cfdc9d49822185da79c1cf5ff57e6d03e2281f84b49e6dc00bf74e1330994bL84-L109): Removed the auto-merge functionality, including the logic to check if a pull request is mergeable and automatically merge it. This change enforces manual merging of pull requests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `update-model-catalog.yml` to add reviewers and remove auto-merge, enforcing manual PR review and merge.
> 
>   - **Workflow Updates**:
>     - In `.github/workflows/update-model-catalog.yml`, added `Minh141120` and `qnixsynapse` as reviewers for auto-generated pull requests.
>     - Removed auto-merge functionality from `.github/workflows/update-model-catalog.yml`, enforcing manual merging of pull requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fmodel-catalog&utm_source=github&utm_medium=referral)<sup> for 53db4261f9f94027a335860258c6c6448bdf6676. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->