### PR TITLE
ci: auto create draft  release on update model catalog pr merged

### DIFF
--- a/.github/workflows/auto-release-on-pr-merge.yml
+++ b/.github/workflows/auto-release-on-pr-merge.yml
@@ -1,0 +1,68 @@
+name: Auto Create Draft Release on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  path:
+    - model_catalog.json
+    - script_output.log
+
+jobs:
+  create-draft-release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '🤖 Auto-update Model Catalog')
+    permissions:
+      contents: write
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set date variables
+        id: date
+        run: |
+          echo "today=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "today_with_time=$(date +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
+          echo "today_readable=$(date +'%d-%m-%Y')" >> $GITHUB_OUTPUT
+          echo "datetime=$(date +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+          echo "datetime_short=$(date +'%d-%m-%Y %H:%M')" >> $GITHUB_OUTPUT
+      
+      - name: Generate version from date
+        id: get_version
+        run: |
+          echo "VERSION=${{ steps.date.outputs.today_with_time }}" >> $GITHUB_ENV
+          echo "version=${{ steps.date.outputs.today_with_time }}" >> $GITHUB_OUTPUT
+      
+      - name: Create Draft Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ steps.date.outputs.today_with_time }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Auto Release - ${{ steps.date.outputs.datetime_short }}"
+          draft: true
+          prerelease: false
+          body: |
+            ## 🤖 Automated Release
+            
+            This release was automatically created after merging the model catalog update PR.
+            
+            **Date:** ${{ steps.date.outputs.datetime_short }}
+            **PR:** #${{ github.event.pull_request.number }}
+            
+            ### Changes
+            - Updated model catalog with latest models
+            - Automated via GitHub Actions workflow
+      
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: ./model_catalog.json
+            asset_name: model_catalog-${{ steps.get_version.outputs.version }}.json
+            asset_content_type: application/json 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of draft releases when specific pull requests are merged into the `main` branch. The workflow is designed to streamline the release process for updates to the model catalog.

### New GitHub Actions Workflow:

* **Workflow Name:** Added a new workflow named `Auto Create Draft Release on PR Merge` to `.github/workflows/auto-release-on-pr-merge.yml`. The workflow triggers on closed pull requests targeting the `main` branch, specifically for PRs with titles starting with "🤖 Auto-update Model Catalog."

* **Draft Release Creation:** The workflow generates a draft release with the following features:
  - Uses the current date and time to generate a version number and tag name.
  - Includes a release name, description, and a list of changes.
  - Marks the release as a draft but not a prerelease.

* **Release Asset Upload:** The workflow uploads the `model_catalog.json` file as a release asset, naming it with the generated version and tagging it as a JSON file.