### PR TITLE
chore: pin jan v1 model

### DIFF
--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -24,7 +24,7 @@ BLACKLISTED_DEVELOPERS = {
     "TheBloke",
 }
 
-PINNED_MODELS = ["ggml-org/gpt-oss-20b-GGUF"]
+PINNED_MODELS = ["janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
 
 client = openai.OpenAI(
     base_url=os.getenv("BASE_URL"),


### PR DESCRIPTION
This pull request makes a small update to the list of pinned models in `prepare_catalog.py`, adding a new model to the catalog.

* Added `"janhq/Jan-v1-4B-GGUF"` to the `PINNED_MODELS` list in `prepare_catalog.py`, ensuring it is included as a pinned model alongside `"ggml-org/gpt-oss-20b-GGUF"`.