### PR TITLE
chore: pin menlo/jan-v1-2509 model

### DIFF
--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -26,7 +26,7 @@ BLACKLISTED_DEVELOPERS = {
     "UmeAiRT",
 }
 
-PINNED_MODELS = ["janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
+PINNED_MODELS = ["Menlo/Jan-v1-2509-gguf","janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
 
 client = openai.OpenAI(
     base_url=os.getenv("BASE_URL"),


### PR DESCRIPTION
This pull request makes a minor update to the list of pinned models in `prepare_catalog.py`, ensuring that a new model is included in the catalog.

* Added `"Menlo/Jan-v1-2509-gguf"` to the `PINNED_MODELS` list to ensure it is available and prioritized in the catalog.