### PR TITLE
chore: change org for jan-v1-2509 model to pin

### DIFF
--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -26,7 +26,7 @@ BLACKLISTED_DEVELOPERS = {
     "UmeAiRT",
 }
 
-PINNED_MODELS = ["Menlo/Jan-v1-2509-gguf","janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
+PINNED_MODELS = ["janhq/Jan-v1-2509-gguf","janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
 
 client = openai.OpenAI(
     base_url=os.getenv("BASE_URL"),


### PR DESCRIPTION
This pull request makes a small change to the `prepare_catalog.py` file, updating the `PINNED_MODELS` list to use the correct model identifier for Jan v1-2509.

* Corrected the model identifier in the `PINNED_MODELS` list from `"Menlo/Jan-v1-2509-gguf"` to `"janhq/Jan-v1-2509-gguf"` to ensure the right model is referenced.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected model identifier in `PINNED_MODELS` list in `prepare_catalog.py` to ensure correct model reference.
> 
>   - **Behavior**:
>     - Corrected model identifier in `PINNED_MODELS` list in `prepare_catalog.py` from `"Menlo/Jan-v1-2509-gguf"` to `"janhq/Jan-v1-2509-gguf"` to ensure correct model reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fmodel-catalog&utm_source=github&utm_medium=referral)<sup> for bfeea97ead14d51cc432c1fe9ba677dfb51a4835. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->