### PR TITLE
chore: pin ernie models

### DIFF
--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -26,7 +26,7 @@ BLACKLISTED_DEVELOPERS = {
     "UmeAiRT",
 }
 
-PINNED_MODELS = ["janhq/Jan-v1-2509-gguf","janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF"]
+PINNED_MODELS = ["janhq/Jan-v1-2509-gguf","janhq/Jan-v1-4B-GGUF", "ggml-org/gpt-oss-20b-GGUF", "bartowski/baidu_ERNIE-4.5-21B-A3B-PT-GGUF", "unsloth/ERNIE-4.5-21B-A3B-PT-GGUF"]
 
 client = openai.OpenAI(
     base_url=os.getenv("BASE_URL"),


### PR DESCRIPTION
This pull request makes a small update to the list of pinned models in the `prepare_catalog.py` script by adding two new model identifiers.

- Added `"bartowski/baidu_ERNIE-4.5-21B-A3B-PT-GGUF"` and `"unsloth/ERNIE-4.5-21B-A3B-PT-GGUF"` to the `PINNED_MODELS` list in `prepare_catalog.py`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add two new model identifiers to `PINNED_MODELS` in `prepare_catalog.py`.
> 
>   - **Models**:
>     - Added `"bartowski/baidu_ERNIE-4.5-21B-A3B-PT-GGUF"` and `"unsloth/ERNIE-4.5-21B-A3B-PT-GGUF"` to `PINNED_MODELS` list in `prepare_catalog.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fmodel-catalog&utm_source=github&utm_medium=referral)<sup> for 1d9d774eb70fbea6c0d6c4813f375564b8060c93. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->