### PR TITLE
Filter GGUF/MLX catalog to chat models only

### DIFF
--- a/catalog_helpers.py
+++ b/catalog_helpers.py
@@ -25,6 +25,80 @@ BLACKLISTED_DEVELOPERS = {
 
 EXCLUDED_GGUF_KEYWORDS = ("embedding", "ocr", "speech", "reranker", "encoder", "clip")
 
+CHAT_PIPELINE_TAGS = {"text-generation", "image-text-to-text"}
+NON_CHAT_PIPELINE_TAGS = {
+    "feature-extraction",
+    "sentence-similarity",
+    "automatic-speech-recognition",
+    "text-classification",
+    "text-to-image",
+    "text-to-speech",
+    "fill-mask",
+    "token-classification",
+    "zero-shot-classification",
+    "summarization",
+    "translation",
+    "question-answering",
+    "image-classification",
+    "object-detection",
+    "image-segmentation",
+    "image-to-text",
+    "audio-classification",
+    "audio-to-audio",
+}
+NON_CHAT_NAME_KEYWORDS = (
+    "embed",
+    "embedding",
+    "reranker",
+    "rerank",
+    "ocr",
+    "whisper",
+    "parakeet",
+    "-tts",
+    "tts-",
+    "text-to-speech",
+    "speech-to-text",
+    "colbert",
+    "text-encoder",
+    "text_encoder",
+)
+
+
+def is_chat_model(detail: dict, require_chat_template: bool = False) -> bool:
+    """Decide if an HF model entry is a chat model (text-only or VLM).
+
+    GGUF repos expose ``gguf.chat_template`` directly — for those we treat its
+    presence as the strongest signal. MLX/transformers repos don't, so we fall
+    back to ``pipeline_tag`` and tags.
+    """
+    gguf_data = detail.get("gguf")
+    if isinstance(gguf_data, dict):
+        ct = gguf_data.get("chat_template")
+        if isinstance(ct, str) and ct.strip():
+            return True
+        if require_chat_template:
+            return False
+
+    pipeline_tag = (detail.get("pipeline_tag") or "").lower()
+    if pipeline_tag in NON_CHAT_PIPELINE_TAGS:
+        return False
+    if pipeline_tag in CHAT_PIPELINE_TAGS:
+        return True
+
+    tags = {str(t).lower() for t in detail.get("tags", [])}
+    if "conversational" in tags:
+        return True
+    if tags & NON_CHAT_PIPELINE_TAGS:
+        return False
+    if tags & CHAT_PIPELINE_TAGS:
+        return True
+    return False
+
+
+def has_non_chat_name(repo_id: str) -> bool:
+    n = repo_id.lower()
+    return any(kw in n for kw in NON_CHAT_NAME_KEYWORDS)
+
 HF_TOKEN = os.getenv("HF_TOKEN")
 HEADERS = {"Authorization": f"Bearer {HF_TOKEN}"} if HF_TOKEN else {}
 
@@ -153,8 +227,13 @@ def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) 
         print(f"Filtering out blacklisted developer: {developer}/{model_name}")
         return None
 
+    if not is_chat_model(detail):
+        print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
+        return None
+
     downloads = detail.get("downloads", 0)
     createdAt = detail.get("createdAt")
+    pipeline_tag = detail.get("pipeline_tag")
 
     supports_tools = False
     gguf_data = detail.get("gguf")
@@ -206,6 +285,7 @@ def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) 
         "developer": developer,
         "downloads": downloads,
         "createdAt": createdAt,
+        "pipeline_tag": pipeline_tag,
         "library_name": "gguf",
         "tools": supports_tools,
         "num_quants": len(quants),
@@ -229,8 +309,17 @@ def process_mlx_model(repo_id: str, detail: dict, existing_entry: dict = None) -
         print(f"Filtering out blacklisted developer: {developer}/{model_name}")
         return None
 
+    if not is_chat_model(detail):
+        print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
+        return None
+
+    if has_non_chat_name(repo_id):
+        print(f"  -> Repo name flagged as non-chat, skipping: {repo_id}")
+        return None
+
     downloads = detail.get("downloads", 0)
     createdAt = detail.get("createdAt")
+    pipeline_tag = detail.get("pipeline_tag")
 
     safetensors_files = []
     readme_url = None
@@ -266,6 +355,7 @@ def process_mlx_model(repo_id: str, detail: dict, existing_entry: dict = None) -
         "developer": developer,
         "downloads": downloads,
         "createdAt": createdAt,
+        "pipeline_tag": pipeline_tag,
         "library_name": "mlx",
         "tools": False,
         "num_safetensors": len(safetensors_files),

--- a/catalog_helpers.py
+++ b/catalog_helpers.py
@@ -227,6 +227,10 @@ def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) 
         print(f"Filtering out blacklisted developer: {developer}/{model_name}")
         return None
 
+    if detect_library_name(detail) != "gguf":
+        print(f"  -> Not a GGUF repo (library_name={detail.get('library_name')}), skipping")
+        return None
+
     if not is_chat_model(detail):
         print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
         return None
@@ -307,6 +311,10 @@ def process_mlx_model(repo_id: str, detail: dict, existing_entry: dict = None) -
 
     if developer in BLACKLISTED_DEVELOPERS:
         print(f"Filtering out blacklisted developer: {developer}/{model_name}")
+        return None
+
+    if detect_library_name(detail) != "mlx":
+        print(f"  -> Not an MLX repo (library_name={detail.get('library_name')}), skipping")
         return None
 
     if not is_chat_model(detail):

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -18,7 +18,73 @@ REQUEST_TIMEOUT = 10  # seconds
 priority_devs = ["Menlo", "janhq", "cortexso"]
 
 # Tags to look for in the summary metadata
-DESIRED_TAGS = {"text-generation", "conversational", "llama", "image-text-to-text"}
+DESIRED_TAGS = {"text-generation", "conversational", "image-text-to-text"}
+
+CHAT_PIPELINE_TAGS = {"text-generation", "image-text-to-text"}
+NON_CHAT_PIPELINE_TAGS = {
+    "feature-extraction",
+    "sentence-similarity",
+    "automatic-speech-recognition",
+    "text-classification",
+    "text-to-image",
+    "text-to-speech",
+    "fill-mask",
+    "token-classification",
+    "zero-shot-classification",
+    "summarization",
+    "translation",
+    "question-answering",
+    "image-classification",
+    "object-detection",
+    "image-segmentation",
+    "image-to-text",
+    "audio-classification",
+    "audio-to-audio",
+}
+NON_CHAT_NAME_KEYWORDS = (
+    "embed",
+    "embedding",
+    "reranker",
+    "rerank",
+    "ocr",
+    "whisper",
+    "-tts",
+    "tts-",
+    "text-to-speech",
+    "speech-to-text",
+    "colbert",
+    "text-encoder",
+    "text_encoder",
+)
+
+
+def is_chat_model(detail: dict) -> bool:
+    """Decide whether a HF model entry represents a chat (or VLM) model."""
+    gguf_data = detail.get("gguf")
+    if isinstance(gguf_data, dict):
+        ct = gguf_data.get("chat_template")
+        if isinstance(ct, str) and ct.strip():
+            return True
+
+    pipeline_tag = (detail.get("pipeline_tag") or "").lower()
+    if pipeline_tag in NON_CHAT_PIPELINE_TAGS:
+        return False
+    if pipeline_tag in CHAT_PIPELINE_TAGS:
+        return True
+
+    tags = {str(t).lower() for t in detail.get("tags", [])}
+    if "conversational" in tags:
+        return True
+    if tags & NON_CHAT_PIPELINE_TAGS:
+        return False
+    if tags & CHAT_PIPELINE_TAGS:
+        return True
+    return False
+
+
+def has_non_chat_name(repo_id: str) -> bool:
+    n = repo_id.lower()
+    return any(kw in n for kw in NON_CHAT_NAME_KEYWORDS)
 
 BLACKLISTED_DEVELOPERS = {
     "TheBloke",
@@ -116,8 +182,13 @@ def process_model_details(repo_id, detail=None, existing_entry=None):
         print(f"Filtering out blacklisted developer: {developer}/{model_name}")
         return None
 
+    if not is_chat_model(detail):
+        print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
+        return None
+
     downloads = detail.get("downloads", 0)
     createdAt = detail.get("createdAt")
+    pipeline_tag = detail.get("pipeline_tag")
 
     # Check for tool support in chat template
     supports_tools = False
@@ -210,6 +281,7 @@ def process_model_details(repo_id, detail=None, existing_entry=None):
         "developer": developer,
         "downloads": downloads,
         "createdAt": createdAt,
+        "pipeline_tag": pipeline_tag,
         "tools": supports_tools,
         "num_quants": len(quants),
         "quants": quants,
@@ -359,6 +431,24 @@ def get_gguf_model_catalog():
                 print(
                     f"  -> Removed {removed_blacklisted} model(s) from blacklisted developers"
                 )
+
+            print("=== FILTERING NON-CHAT MODELS FROM EXISTING CATALOG ===")
+            pre_chat_count = len(existing_catalog)
+            kept_catalog = []
+            for entry in existing_catalog:
+                repo_id = f"{entry.get('developer','')}/{entry.get('model_name','')}"
+                pt = (entry.get("pipeline_tag") or "").lower()
+                if pt in NON_CHAT_PIPELINE_TAGS:
+                    print(f"  -> Removing non-chat model (pipeline_tag={pt}): {repo_id}")
+                    continue
+                if has_non_chat_name(repo_id):
+                    print(f"  -> Removing non-chat model by name: {repo_id}")
+                    continue
+                kept_catalog.append(entry)
+            existing_catalog = kept_catalog
+            removed_non_chat = pre_chat_count - len(existing_catalog)
+            if removed_non_chat > 0:
+                print(f"  -> Removed {removed_non_chat} non-chat model(s)")
             # Separate mmproj models from existing catalog entries
             print("=== SEPARATING MMPROJ FROM EXISTING CATALOG ===")
             for entry in existing_catalog:
@@ -473,8 +563,9 @@ def get_gguf_model_catalog():
                 "quants",
                 "readme",
                 "description",
-                "mmproj_models",  # Added mmproj_models to expected keys
-                "num_mmproj",  # Added num_mmproj to expected keys
+                "mmproj_models",
+                "num_mmproj",
+                "pipeline_tag",
             ]
             if existing_entry is None:
                 # New entry
@@ -573,6 +664,7 @@ def get_gguf_model_catalog():
             "description",
             "mmproj_models",
             "num_mmproj",
+            "pipeline_tag",
         ]
         missing_keys = []
 
@@ -596,6 +688,11 @@ def get_gguf_model_catalog():
             )
             r.raise_for_status()
             detail = r.json()
+
+            if not is_chat_model(detail):
+                print(f"  -> Existing entry is not a chat model, removing: {repo_id}")
+                del existing_map[entry_key]
+                continue
 
             # Extract basic info
             downloads = detail.get("downloads", existing_entry.get("downloads", 0))
@@ -709,6 +806,7 @@ def get_gguf_model_catalog():
                 "developer": existing_entry.get("developer", repo_id.split("/")[0]),
                 "downloads": downloads,
                 "createdAt": createdAt,
+                "pipeline_tag": detail.get("pipeline_tag", existing_entry.get("pipeline_tag")),
                 "tools": supports_tools,
                 "num_quants": (
                     len(quants) if quants else existing_entry.get("num_quants", 0)

--- a/prepare_catalog_v2.py
+++ b/prepare_catalog_v2.py
@@ -19,7 +19,9 @@ from catalog_helpers import (
     BLACKLISTED_DEVELOPERS,
     HEADERS,
     HF_BASE_API_URL,
+    NON_CHAT_PIPELINE_TAGS,
     REQUEST_TIMEOUT,
+    has_non_chat_name,
     process_gguf_model,
     process_mlx_model,
 )
@@ -33,8 +35,8 @@ REQUEST_DELAY = 0.1
 priority_devs = ["Menlo", "janhq", "cortexso", "mlx-community"]
 
 # Tags to look for
-DESIRED_TAGS_GGUF = {"text-generation", "conversational", "llama", "image-text-to-text"}
-DESIRED_TAGS_MLX = {"text-generation", "conversational", "mlx"}
+DESIRED_TAGS_GGUF = {"text-generation", "conversational", "image-text-to-text"}
+DESIRED_TAGS_MLX = {"text-generation", "conversational", "image-text-to-text"}
 
 PINNED_GGUF_MODELS = [
     "janhq/Jan-v3.5-4B-gguf",
@@ -72,11 +74,31 @@ def load_existing_v2_catalog() -> dict:
     if os.path.exists(OUTPUT_FILE_V2):
         with open(OUTPUT_FILE_V2, "r", encoding="utf-8") as f:
             catalog = json.load(f)
-            for entry in catalog:
-                key = f"{entry.get('developer', '')}/{entry.get('model_name', '')}"
-                if key != "/":
-                    existing_map[key] = entry
-        print(f"Loaded {len(existing_map)} existing entries from {OUTPUT_FILE_V2}")
+        dropped_blacklisted = 0
+        dropped_non_chat = 0
+        for entry in catalog:
+            developer = entry.get("developer", "")
+            model_name = entry.get("model_name", "")
+            key = f"{developer}/{model_name}"
+            if key == "/":
+                continue
+            if developer in BLACKLISTED_DEVELOPERS:
+                dropped_blacklisted += 1
+                continue
+            pt = (entry.get("pipeline_tag") or "").lower()
+            if pt in NON_CHAT_PIPELINE_TAGS:
+                print(f"  -> Dropping non-chat existing entry (pipeline_tag={pt}): {key}")
+                dropped_non_chat += 1
+                continue
+            if has_non_chat_name(key):
+                print(f"  -> Dropping non-chat existing entry by name: {key}")
+                dropped_non_chat += 1
+                continue
+            existing_map[key] = entry
+        print(
+            f"Loaded {len(existing_map)} existing entries from {OUTPUT_FILE_V2} "
+            f"(dropped {dropped_blacklisted} blacklisted, {dropped_non_chat} non-chat)"
+        )
     return existing_map
 
 
@@ -136,7 +158,11 @@ def fetch_gguf_models(existing_map: dict) -> list:
             # Skip if existing entry is up to date (same downloads)
             downloads = summary.get("downloads", 0)
             if existing_entry and existing_entry.get("library_name") == "gguf":
-                if existing_entry.get("downloads") == downloads and existing_entry.get("description"):
+                if (
+                    existing_entry.get("downloads") == downloads
+                    and existing_entry.get("description")
+                    and "pipeline_tag" in existing_entry
+                ):
                     gguf_models.append(existing_entry)
                     continue
 
@@ -247,9 +273,19 @@ def fetch_mlx_models(existing_map: dict) -> list:
                 # Skip if existing entry is up to date
                 downloads = summary.get("downloads", 0)
                 if existing_entry and existing_entry.get("library_name") == "mlx":
-                    if existing_entry.get("downloads") == downloads and existing_entry.get("description"):
+                    if (
+                        existing_entry.get("downloads") == downloads
+                        and existing_entry.get("description")
+                        and "pipeline_tag" in existing_entry
+                    ):
                         mlx_models.append(existing_entry)
                         continue
+
+                summary_tags = {str(t).lower() for t in summary.get("tags", [])}
+                if summary_tags & NON_CHAT_PIPELINE_TAGS:
+                    continue
+                if has_non_chat_name(repo_id):
+                    continue
 
                 print(f"Processing MLX: {repo_id}")
 


### PR DESCRIPTION
## Describe Your Changes

- Reject non-chat repos (embeddings, OCR, TTS, ASR, rerankers, encoders) using HF API signals: gguf.chat_template presence, pipeline_tag allow/deny lists, and a name-keyword sweep for existing entries. Store pipeline_tag on each entry and add it to expected_keys so prior entries get re-validated on next run.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed