### PR TITLE
Bypass chat-model check for pinned models

### DIFF
--- a/catalog_helpers.py
+++ b/catalog_helpers.py
@@ -215,8 +215,18 @@ def _resolve_description(readme_text: str | None, existing_entry: dict | None) -
     return description
 
 
-def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) -> dict | None:
-    """Process GGUF model details. Returns None if model should be skipped."""
+def process_gguf_model(
+    repo_id: str,
+    detail: dict,
+    existing_entry: dict = None,
+    is_pinned: bool = False,
+) -> dict | None:
+    """Process GGUF model details. Returns None if model should be skipped.
+
+    When ``is_pinned`` is True, the chat-model gate is bypassed so pinned
+    repos are kept even if HF returns ``pipeline_tag = None`` and no other
+    chat signals are present.
+    """
     if not detail:
         return None
 
@@ -231,9 +241,11 @@ def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) 
         print(f"  -> Not a GGUF repo (library_name={detail.get('library_name')}), skipping")
         return None
 
-    if not is_chat_model(detail):
+    if not is_pinned and not is_chat_model(detail):
         print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
         return None
+    if is_pinned and not is_chat_model(detail):
+        print(f"  -> Pinned override: keeping despite chat-model check (pipeline_tag={detail.get('pipeline_tag')})")
 
     downloads = detail.get("downloads", 0)
     createdAt = detail.get("createdAt")
@@ -301,8 +313,17 @@ def process_gguf_model(repo_id: str, detail: dict, existing_entry: dict = None) 
     }
 
 
-def process_mlx_model(repo_id: str, detail: dict, existing_entry: dict = None) -> dict | None:
-    """Process MLX model details. Returns None if model should be skipped."""
+def process_mlx_model(
+    repo_id: str,
+    detail: dict,
+    existing_entry: dict = None,
+    is_pinned: bool = False,
+) -> dict | None:
+    """Process MLX model details. Returns None if model should be skipped.
+
+    When ``is_pinned`` is True, the chat-model and non-chat-name gates are
+    bypassed so pinned repos are kept even when HF metadata is missing.
+    """
     if not detail:
         return None
 
@@ -317,11 +338,13 @@ def process_mlx_model(repo_id: str, detail: dict, existing_entry: dict = None) -
         print(f"  -> Not an MLX repo (library_name={detail.get('library_name')}), skipping")
         return None
 
-    if not is_chat_model(detail):
+    if not is_pinned and not is_chat_model(detail):
         print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
         return None
+    if is_pinned and not is_chat_model(detail):
+        print(f"  -> Pinned override: keeping despite chat-model check (pipeline_tag={detail.get('pipeline_tag')})")
 
-    if has_non_chat_name(repo_id):
+    if not is_pinned and has_non_chat_name(repo_id):
         print(f"  -> Repo name flagged as non-chat, skipping: {repo_id}")
         return None
 

--- a/prepare_catalog.py
+++ b/prepare_catalog.py
@@ -166,7 +166,7 @@ def is_mmproj_file(filename):
     return name.startswith("mmproj") and name.endswith(".gguf")
 
 
-def process_model_details(repo_id, detail=None, existing_entry=None):
+def process_model_details(repo_id, detail=None, existing_entry=None, is_pinned=False):
     """
     Process model details from HF API response and return structured entry.
     Returns None if model should be skipped.
@@ -183,8 +183,11 @@ def process_model_details(repo_id, detail=None, existing_entry=None):
         return None
 
     if not is_chat_model(detail):
-        print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
-        return None
+        if is_pinned:
+            print(f"  -> Pinned override: keeping despite chat-model check (pipeline_tag={detail.get('pipeline_tag')})")
+        else:
+            print(f"  -> Not a chat model (pipeline_tag={detail.get('pipeline_tag')}), skipping")
+            return None
 
     downloads = detail.get("downloads", 0)
     createdAt = detail.get("createdAt")
@@ -852,7 +855,7 @@ def get_gguf_model_catalog():
                 print(f"  -> Successfully fetched pinned model details")
 
                 # Process the pinned model details
-                entry = process_model_details(pinned_repo_id, detail)
+                entry = process_model_details(pinned_repo_id, detail, is_pinned=True)
                 if entry is not None:
                     existing_map[pinned_repo_id] = entry
                     added_or_updated += 1

--- a/prepare_catalog_v2.py
+++ b/prepare_catalog_v2.py
@@ -214,7 +214,7 @@ def fetch_gguf_models(existing_map: dict) -> list:
             r.raise_for_status()
             detail = r.json()
 
-            entry = process_gguf_model(pinned_repo_id, detail, existing_entry)
+            entry = process_gguf_model(pinned_repo_id, detail, existing_entry, is_pinned=True)
             if entry:
                 gguf_models.append(entry)
                 print(f"  -> Added pinned GGUF model")
@@ -329,7 +329,7 @@ def fetch_mlx_models(existing_map: dict) -> list:
             r.raise_for_status()
             detail = r.json()
 
-            entry = process_mlx_model(pinned_repo_id, detail, existing_entry)
+            entry = process_mlx_model(pinned_repo_id, detail, existing_entry, is_pinned=True)
             if entry:
                 mlx_models.append(entry)
                 print(f"  -> Added pinned MLX model")


### PR DESCRIPTION
## Describe Your Changes

- Pinned repos with missing/None pipeline_tag and no other chat signals were silently dropped by process_gguf_model / process_mlx_model / process_model_details. Add an is_pinned flag that skips the is_chat_model (and has_non_chat_name for MLX) gates so pinned entries are always kept when format and siblings checks pass.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed