### PR TITLE
Add soft pipeline_tag deny-list for chat-LLM false positives

### DIFF
--- a/catalog_helpers.py
+++ b/catalog_helpers.py
@@ -36,9 +36,6 @@ NON_CHAT_PIPELINE_TAGS = {
     "fill-mask",
     "token-classification",
     "zero-shot-classification",
-    "summarization",
-    "translation",
-    "question-answering",
     "image-classification",
     "object-detection",
     "image-segmentation",
@@ -51,6 +48,20 @@ NON_CHAT_PIPELINE_TAGS = {
     "video-classification",
     "text-to-3d",
     "image-to-3d",
+    "time-series-forecasting",
+    "zero-shot-image-classification",
+    "text-ranking",
+    "voice-activity-detection",
+    "image-feature-extraction",
+    "any-to-any",
+    "mask-generation",
+}
+# Text-output tasks that LLMs are often fine-tuned for. HF mislabels many chat
+# GGUF/MLX repos with these, so we only reject when no chat_template is present.
+SOFT_NON_CHAT_PIPELINE_TAGS = {
+    "question-answering",
+    "summarization",
+    "translation",
 }
 NON_CHAT_NAME_KEYWORDS = (
     "embed",
@@ -88,6 +99,9 @@ def is_chat_model(detail: dict, require_chat_template: bool = False) -> bool:
             return True
         if require_chat_template:
             return False
+
+    if pipeline_tag in SOFT_NON_CHAT_PIPELINE_TAGS:
+        return False
 
     if pipeline_tag in CHAT_PIPELINE_TAGS:
         return True


### PR DESCRIPTION
## Describe Your Changes

- HF often mislabels chat-LLM GGUF/MLX fine-tunes with text-output task tags like question-answering, summarization, translation. The hard deny-list rejected these before the gguf.chat_template shortcut could rescue them, dropping models like Qwen3.5/Llama-Instruct/Phi-4 GGUFs.

- Move question-answering, summarization, translation out of NON_CHAT_PIPELINE_TAGS into a new SOFT_NON_CHAT_PIPELINE_TAGS set.
- Check soft deny only after the gguf.chat_template shortcut, so a real chat_template overrides the mislabel.
- Hard deny (video/3d/audio/image/embeddings/classification) still wins over chat_template, preserving the SulphurAI bundled-sub-model fix from 64d55aa.
- Also add time-series-forecasting, zero-shot-image-classification, text-ranking, voice-activity-detection, image-feature-extraction, any-to-any, mask-generation to the hard deny-list (observed in the top GGUF/MLX candidate set, none produce text output).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed