### PR TITLE
Demote any-to-any to soft deny-list

### DIFF
--- a/catalog_helpers.py
+++ b/catalog_helpers.py
@@ -53,15 +53,17 @@ NON_CHAT_PIPELINE_TAGS = {
     "text-ranking",
     "voice-activity-detection",
     "image-feature-extraction",
-    "any-to-any",
     "mask-generation",
 }
 # Text-output tasks that LLMs are often fine-tuned for. HF mislabels many chat
 # GGUF/MLX repos with these, so we only reject when no chat_template is present.
+# `any-to-any` covers multimodal chat models like Gemma 4 E2B/E4B that output
+# text (and other modalities) — keep if a chat_template is present.
 SOFT_NON_CHAT_PIPELINE_TAGS = {
     "question-answering",
     "summarization",
     "translation",
+    "any-to-any",
 }
 NON_CHAT_NAME_KEYWORDS = (
     "embed",


### PR DESCRIPTION
## Describe Your Changes

- Gemma 4 E2B/E4B (and uncensored derivatives) are multimodal chat models tagged any-to-any on HF. They output text and ship a chat_template in GGUF. The hard deny added in the previous commit caused regressions in the 2026-05-19 auto-update run — several real chat models dropped.

Move any-to-any to SOFT_NON_CHAT_PIPELINE_TAGS so gguf.chat_template overrides it; MLX repos without a chat_template still fall through to rejection.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed